### PR TITLE
Fix GitHub Pages build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,5 +3,7 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
+  // Base path required for correct asset loading on GitHub Pages.
+  base: '/azure-llm-sizer/',
   plugins: [react()],
 })


### PR DESCRIPTION
## Summary
- set `base` in Vite config so built assets are loaded from `/azure-llm-sizer/`

## Testing
- `npm run build`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6878fcc9cda08322a1a6485aa0c2b42a