### PR TITLE
Add sortable scrollable model selection

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -79,11 +79,24 @@ body {
     gap: 0.5rem;
 }
 
+.model-sort {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+}
+
+.model-list {
+    max-height: 300px;
+    overflow-y: auto;
+    margin-bottom: 2rem;
+    padding-right: 0.5rem;
+}
+
 .model-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
     gap: 1rem;
-    margin-bottom: 2rem;
 }
 
 .model-btn {


### PR DESCRIPTION
## Summary
- make `Select Model` list scrollable
- sort models by size by default
- allow size/name sort options

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687bcbc251b08322bf6aee4645d06ded