### PR TITLE
Improve slider defaults and layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -29,12 +29,12 @@ body {
 .container {
     max-width: 1200px;
     margin: 0 auto;
-    padding: 2rem;
+    padding: 1.5rem;
 }
 
 .header {
     text-align: center;
-    margin-bottom: 3rem;
+    margin-bottom: 2rem;
     color: white;
 }
 
@@ -57,7 +57,7 @@ body {
     border-radius: var(--border-radius);
     box-shadow: var(--card-shadow);
     padding: 2.5rem;
-    margin-bottom: 2rem;
+    margin-bottom: 1rem;
     transition: var(--transition);
 }
 
@@ -66,7 +66,7 @@ body {
 }
 
 .section {
-    margin-bottom: 2.5rem;
+    margin-bottom: 1.5rem;
 }
 
 .section-title {
@@ -192,17 +192,24 @@ body {
 
 .slider {
     width: 100%;
-    height: 6px;
-    border-radius: 3px;
-    background: #E1E1E1;
+    height: 8px;
+    border-radius: 4px;
+    background: linear-gradient(
+        to right,
+        var(--primary-blue) 0%,
+        var(--primary-blue) var(--progress),
+        #E1E1E1 var(--progress)
+    );
     outline: none;
     -webkit-appearance: none;
+    appearance: none;
+    transition: background 0.3s ease;
 }
 
 .slider::-webkit-slider-thumb {
     -webkit-appearance: none;
-    width: 20px;
-    height: 20px;
+    width: 22px;
+    height: 22px;
     border-radius: 50%;
     background: var(--primary-blue);
     cursor: pointer;
@@ -210,8 +217,8 @@ body {
 }
 
 .slider::-moz-range-thumb {
-    width: 20px;
-    height: 20px;
+    width: 22px;
+    height: 22px;
     border-radius: 50%;
     background: var(--primary-blue);
     cursor: pointer;
@@ -278,7 +285,7 @@ body {
     background: var(--secondary-gray);
     border-radius: var(--border-radius);
     padding: 2rem;
-    margin-top: 2rem;
+    margin-top: 1rem;
     opacity: 0;
     transform: translateY(20px);
     transition: var(--transition);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,7 +33,8 @@ const MAX_MEM = 160; // for progress bar scaling
 function App() {
   const [modelId, setModelId] = useState<string>((models as ModelInfo[])[0].model_id);
   const [precision, setPrecision] = useState<Precision>('fp16');
-  const [ctxIndex, setCtxIndex] = useState<number>(2);
+  // default to 128k context length
+  const [ctxIndex, setCtxIndex] = useState<number>(7);
   const [result, setResult] = useState<ReturnType<typeof estimateWithSku> | null>(null);
   const [loading, setLoading] = useState(false);
   const [copied, setCopied] = useState(false);
@@ -170,6 +171,9 @@ function App() {
                   step={1}
                   value={ctxIndex}
                   onChange={(e) => setCtxIndex(Number(e.target.value))}
+                  style={{
+                    '--progress': `${(ctxIndex / (ctxOptions.length - 1)) * 100}%`,
+                  } as React.CSSProperties}
                 />
                 <div className="slider-labels">
                   {ctxOptions.map((v) => (


### PR DESCRIPTION
## Summary
- default slider to 128k tokens
- add progress styling to slider and enlarge thumb
- shrink padding/margins so results show without scrolling

## Testing
- `npm ci`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687bf67920148322b39aa022c87b6115