### PR TITLE
Add docs links to sku data

### DIFF
--- a/data/azure-gpus.json
+++ b/data/azure-gpus.json
@@ -3,126 +3,147 @@
     "sku": "Standard_NC16as_T4_v3",
     "gpu_model": "T4",
     "gpus_per_vm": 1,
-    "vram_gb": 16
+    "vram_gb": 16,
+    "docs_url": "https://learn.microsoft.com/azure/virtual-machines/sizes/gpu-accelerated/nc-family#ncast4_v3-series"
   },
   {
     "sku": "Standard_NC24ads_A100_v4",
     "gpu_model": "A100",
     "gpus_per_vm": 1,
-    "vram_gb": 40
+    "vram_gb": 40,
+    "docs_url": "https://learn.microsoft.com/azure/virtual-machines/sizes/gpu-accelerated/nc-family#nc_a100_v4-series"
   },
   {
     "sku": "Standard_NC40ads_H100_v5",
     "gpu_model": "H100",
     "gpus_per_vm": 1,
-    "vram_gb": 80
+    "vram_gb": 80,
+    "docs_url": "https://learn.microsoft.com/azure/virtual-machines/sizes/gpu-accelerated/nc-family#ncads_h100_v5-series"
   },
   {
     "sku": "Standard_NC48ads_A100_v4",
     "gpu_model": "A100",
     "gpus_per_vm": 2,
-    "vram_gb": 40
+    "vram_gb": 40,
+    "docs_url": "https://learn.microsoft.com/azure/virtual-machines/sizes/gpu-accelerated/nc-family#nc_a100_v4-series"
   },
   {
     "sku": "Standard_NC4as_T4_v3",
     "gpu_model": "T4",
     "gpus_per_vm": 1,
-    "vram_gb": 16
+    "vram_gb": 16,
+    "docs_url": "https://learn.microsoft.com/azure/virtual-machines/sizes/gpu-accelerated/nc-family#ncast4_v3-series"
   },
   {
     "sku": "Standard_NC64as_T4_v3",
     "gpu_model": "T4",
     "gpus_per_vm": 4,
-    "vram_gb": 16
+    "vram_gb": 16,
+    "docs_url": "https://learn.microsoft.com/azure/virtual-machines/sizes/gpu-accelerated/nc-family#ncast4_v3-series"
   },
   {
     "sku": "Standard_NC80adis_H100_v5",
     "gpu_model": "H100",
     "gpus_per_vm": 2,
-    "vram_gb": 80
+    "vram_gb": 80,
+    "docs_url": "https://learn.microsoft.com/azure/virtual-machines/sizes/gpu-accelerated/nc-family#ncads_h100_v5-series"
   },
   {
     "sku": "Standard_NC8as_T4_v3",
     "gpu_model": "T4",
     "gpus_per_vm": 1,
-    "vram_gb": 16
+    "vram_gb": 16,
+    "docs_url": "https://learn.microsoft.com/azure/virtual-machines/sizes/gpu-accelerated/nc-family#ncast4_v3-series"
   },
   {
     "sku": "Standard_NC96ads_A100_v4",
     "gpu_model": "A100",
     "gpus_per_vm": 4,
-    "vram_gb": 40
+    "vram_gb": 40,
+    "docs_url": "https://learn.microsoft.com/azure/virtual-machines/sizes/gpu-accelerated/nc-family#nc_a100_v4-series"
   },
   {
     "sku": "Standard_ND96amsr_A100_v4",
     "gpu_model": "A100",
     "gpus_per_vm": 8,
-    "vram_gb": 80
+    "vram_gb": 80,
+    "docs_url": "https://learn.microsoft.com/azure/virtual-machines/sizes/gpu-accelerated/nd-family#ndm_a100_v4-series"
   },
   {
     "sku": "Standard_ND96isr_H100_v5",
     "gpu_model": "H100",
     "gpus_per_vm": 8,
-    "vram_gb": 80
+    "vram_gb": 80,
+    "docs_url": "https://learn.microsoft.com/azure/virtual-machines/sizes/gpu-accelerated/nd-family#nd_h100_v5-series"
   },
   {
     "sku": "Standard_NV12ads_A10_v5",
     "gpu_model": "A10",
     "gpus_per_vm": 1,
-    "vram_gb": 24
+    "vram_gb": 24,
+    "docs_url": "https://learn.microsoft.com/azure/virtual-machines/sizes/gpu-accelerated/nv-family#nvads-a10-v5-series"
   },
   {
     "sku": "Standard_NV16as_v4",
     "gpu_model": "MI25",
     "gpus_per_vm": 1,
-    "vram_gb": 16
+    "vram_gb": 16,
+    "docs_url": "https://learn.microsoft.com/azure/virtual-machines/sizes/gpu-accelerated/nv-family#nvv4-series"
   },
   {
     "sku": "Standard_NV18ads_A10_v5",
     "gpu_model": "A10",
     "gpus_per_vm": 1,
-    "vram_gb": 24
+    "vram_gb": 24,
+    "docs_url": "https://learn.microsoft.com/azure/virtual-machines/sizes/gpu-accelerated/nv-family#nvads-a10-v5-series"
   },
   {
     "sku": "Standard_NV32as_v4",
     "gpu_model": "MI25",
     "gpus_per_vm": 1,
-    "vram_gb": 16
+    "vram_gb": 16,
+    "docs_url": "https://learn.microsoft.com/azure/virtual-machines/sizes/gpu-accelerated/nv-family#nvv4-series"
   },
   {
     "sku": "Standard_NV36adms_A10_v5",
     "gpu_model": "A10",
     "gpus_per_vm": 1,
-    "vram_gb": 24
+    "vram_gb": 24,
+    "docs_url": "https://learn.microsoft.com/azure/virtual-machines/sizes/gpu-accelerated/nv-family#nvads-a10-v5-series"
   },
   {
     "sku": "Standard_NV36ads_A10_v5",
     "gpu_model": "A10",
     "gpus_per_vm": 1,
-    "vram_gb": 24
+    "vram_gb": 24,
+    "docs_url": "https://learn.microsoft.com/azure/virtual-machines/sizes/gpu-accelerated/nv-family#nvads-a10-v5-series"
   },
   {
     "sku": "Standard_NV4as_v4",
     "gpu_model": "MI25",
     "gpus_per_vm": 1,
-    "vram_gb": 16
+    "vram_gb": 16,
+    "docs_url": "https://learn.microsoft.com/azure/virtual-machines/sizes/gpu-accelerated/nv-family#nvv4-series"
   },
   {
     "sku": "Standard_NV6ads_A10_v5",
     "gpu_model": "A10",
     "gpus_per_vm": 1,
-    "vram_gb": 24
+    "vram_gb": 24,
+    "docs_url": "https://learn.microsoft.com/azure/virtual-machines/sizes/gpu-accelerated/nv-family#nvads-a10-v5-series"
   },
   {
     "sku": "Standard_NV72ads_A10_v5",
     "gpu_model": "A10",
     "gpus_per_vm": 2,
-    "vram_gb": 24
+    "vram_gb": 24,
+    "docs_url": "https://learn.microsoft.com/azure/virtual-machines/sizes/gpu-accelerated/nv-family#nvads-a10-v5-series"
   },
   {
     "sku": "Standard_NV8as_v4",
     "gpu_model": "MI25",
     "gpus_per_vm": 1,
-    "vram_gb": 16
+    "vram_gb": 16,
+    "docs_url": "https://learn.microsoft.com/azure/virtual-machines/sizes/gpu-accelerated/nv-family#nvv4-series"
   }
 ]

--- a/src/App.css
+++ b/src/App.css
@@ -464,6 +464,20 @@ body {
     opacity: 0.9;
 }
 
+.docs-link {
+    margin-top: 1rem;
+    text-align: right;
+}
+
+.docs-link a {
+    color: var(--primary-blue);
+    text-decoration: none;
+}
+
+.docs-link a:hover {
+    text-decoration: underline;
+}
+
 @media (max-width: 768px) {
     .container {
         padding: 1rem;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -88,6 +88,7 @@ function App() {
 
   const formatCtx = (v: number) => (v >= 1024 ? `${v / 1024}k` : v.toString());
 
+
   const handleCopy = (text: string) => {
     navigator.clipboard.writeText(text).then(() => {
       setCopied(true);
@@ -270,6 +271,11 @@ function App() {
                   <div className="command-text" id="command-text">
                     {`az vm create --name llm --size ${result.sku.sku} --image UbuntuLTS`}
                   </div>
+                </div>
+                <div className="docs-link">
+                  <a href={result.sku.docs_url} target="_blank" rel="noopener noreferrer">
+                    View Azure Learn docs for this VM family
+                  </a>
                 </div>
               </>
             ) : (

--- a/src/estimator.ts
+++ b/src/estimator.ts
@@ -31,6 +31,7 @@ export interface AzureGpuSku {
   gpu_model: string;
   gpus_per_vm: number;
   vram_gb: number;
+  docs_url: string;
 }
 
 export interface EstimateFullInput extends EstimateInput {


### PR DESCRIPTION
## Summary
- attach Azure docs URLs directly to each entry in `azure-gpus.json`
- include new `docs_url` field in `AzureGpuSku` interface
- read link from `result.sku.docs_url` when showing recommended VM family
- fix all docs links to point to the correct VM family anchors

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687e27904e04832298711ca049a151bb