### PR TITLE
Add click-away handler for model dropdown

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, useRef } from 'react';
 import models from '../data/models.json';
 import skus from '../data/azure-gpus.json';
 import type { EstimateFullInput, Precision, AzureGpuSku } from './estimator';
@@ -77,10 +77,21 @@ function App() {
   const [sortOption, setSortOption] = useState<SortOption>('size_desc');
   const [search, setSearch] = useState(query.search);
   const [dropdownOpen, setDropdownOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
 
   const lastUpdated = useMemo(() => new Date().toLocaleDateString(), []);
 
   const ctx = ctxOptions[ctxIndex];
+
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setDropdownOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, []);
 
 
   // update the query string whenever relevant state changes
@@ -197,7 +208,7 @@ function App() {
                 <option value="name">Name</option>
               </select>
             </div>
-            <div className="relative">
+            <div className="relative" ref={dropdownRef}>
               <label className="block mb-2 text-sm font-semibold text-gray-700">Select Model</label>
               <div className="relative">
                 <input


### PR DESCRIPTION
## Summary
- close the model dropdown when clicking outside

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687f88b1d6c483228364a76eb43c4fdc