### PR TITLE
Add calculation details panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Try the hosted version at [frankiey.github.io/azure-llm-sizer](https://frankiey.github.io/azure-llm-sizer).
 
+The results section includes a **How it works?** link that expands a short explanation of the memory estimation formula.
+
 This is an independent project and is not affiliated with Microsoft.
 
 ## Project structure

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState, useRef } from 'react';
+import CalculationDetails from './CalculationDetails';
 import models from '../data/models.json';
 import skus from '../data/azure-gpus.json';
 import type { EstimateFullInput, Precision, AzureGpuSku } from './estimator';
@@ -77,6 +78,7 @@ function App() {
   const [sortOption, setSortOption] = useState<SortOption>('size_desc');
   const [search, setSearch] = useState(query.search);
   const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [showDetails, setShowDetails] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   const lastUpdated = useMemo(() => new Date().toLocaleDateString(), []);
@@ -307,9 +309,18 @@ function App() {
         <div className="lg:col-span-3">
           {result && (
             <div id="results" className="glass-card rounded-2xl shadow-xl p-6 hover-lift transition-all duration-300 fade-in">
-              <h2 className="text-2xl font-bold text-gray-800 mb-6 flex items-center gap-3">
-                📊 <span>Resource Requirements</span>
-              </h2>
+              <div className="flex items-center justify-between mb-6">
+                <h2 className="text-2xl font-bold text-gray-800 flex items-center gap-3">
+                  📊 <span>Resource Requirements</span>
+                </h2>
+                <button
+                  id="details-btn"
+                  className="text-sm text-blue-600 hover:underline"
+                  onClick={() => setShowDetails((v) => !v)}
+                >
+                  {showDetails ? 'Hide details' : 'How it works?'}
+                </button>
+              </div>
 
               <div className="grid md:grid-cols-2 gap-4 mb-8">
                 <div className="bg-gradient-to-br from-green-50 to-green-100 p-4 rounded-xl border-l-4 border-green-500">
@@ -356,6 +367,8 @@ function App() {
                   </div>
                 </div>
               </div>
+
+              {showDetails && <CalculationDetails />}
 
               {result.sku ? (
                 <>

--- a/src/CalculationDetails.tsx
+++ b/src/CalculationDetails.tsx
@@ -1,0 +1,25 @@
+function CalculationDetails() {
+  return (
+    <div className="glass-card rounded-2xl shadow-xl p-6 mt-4 fade-in">
+      <h3 className="text-xl font-bold text-gray-800 mb-4">Calculation details</h3>
+      <p className="text-gray-700 mb-2">
+        Memory requirements are derived from your selected model configuration.
+        Model weights are computed as <code>parameters × bytes-per-parameter</code>
+        based on the chosen precision.
+      </p>
+      <p className="text-gray-700 mb-2">
+        The KV cache consumes
+        <code>2 × layers × context × hidden × bytes × batch</code> and an
+        additional 20% overhead is added for miscellaneous allocations. When
+        training, a further <code>2.5×</code> the model weights is reserved for
+        optimizer state.
+      </p>
+      <p className="text-gray-700">
+        The app then finds the smallest Azure GPU VM SKU whose VRAM can hold the
+        total memory and reports the number of GPUs required.
+      </p>
+    </div>
+  );
+}
+
+export default CalculationDetails;


### PR DESCRIPTION
## Summary
- show explanation of memory estimation steps
- toggle calculation details with a new button in the results card
- document the new explanation feature

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6880b02d2b4883229eaa0537fc75ca27