### PR TITLE
Add share link near documentation link

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -474,6 +474,12 @@ function App() {
                     >
                       📚 View Azure Documentation
                     </a>
+                    <button
+                      className="bg-blue-600 hover:bg-blue-700 text-white px-3 py-2 rounded-lg transition-colors text-sm"
+                      onClick={() => handleCopy(window.location.href)}
+                    >
+                      🔗 Copy share link
+                    </button>
                     <div className="text-gray-600">
                       Last updated: <span id="last-updated">{lastUpdated}</span>
                     </div>


### PR DESCRIPTION
## Summary
- add a Copy share link button beside the Azure docs link

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68838681a58083229738f7b03d1bc50c