### PR TITLE
Change copy link button styling to match doc link

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -468,7 +468,7 @@ function App() {
                       📚 View Azure Documentation
                     </a>
                     <button
-                      className="bg-blue-600 hover:bg-blue-700 text-white px-3 py-2 rounded-lg transition-colors text-sm"
+                      className="text-blue-600 hover:text-blue-800 underline font-medium transition-colors"
                       onClick={() => handleCopy(window.location.href)}
                     >
                       🔗 Copy share link


### PR DESCRIPTION
## Summary
- restyle the "Copy share link" button so it matches the look of the "View Azure Documentation" link

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688cb734aa748322adf58e2c60954fc3