### PR TITLE
Add bf16 precision option

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,7 @@ interface ModelInfo {
 
 type SortOption = 'size_desc' | 'size_asc' | 'name';
 
-const precisions: Precision[] = ['fp16', 'fp32', 'int8', 'int4'];
+const precisions: Precision[] = ['fp16', 'bf16', 'fp32', 'int8', 'int4'];
 const ctxOptions = [
   1024,
   2048,


### PR DESCRIPTION
## Summary
- expose a new `bf16` precision option in the UI so users can choose bf16

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688ccb8072a88322b51b471bfb79d035