### PR TITLE
Disable browser autocomplete on model search field

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -269,6 +269,10 @@ function App() {
                   placeholder="Search for models..."
                   type="text"
                   value={search}
+                  autoComplete="off"
+                  autoCorrect="off"
+                  autoCapitalize="off"
+                  spellCheck={false}
                   onChange={(e) => {
                     setSearch(e.target.value);
                     setDropdownOpen(true);


### PR DESCRIPTION
## Summary
- prevent browser autofill suggestions from appearing on the model search field by disabling autocomplete, autocorrect, autocapitalize, and spellcheck

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890888dc74c8322bf05bb4567cd9b7e